### PR TITLE
Add homepage so bundler stops complaining

### DIFF
--- a/env_guard.gemspec
+++ b/env_guard.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["dimroc@gmail.com"]
 
   spec.summary       = %q{Easily flag an environment for basic auth. Useful to protect staging.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "http://experiments.dimroc.com/"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.

--- a/lib/env_guard.rb
+++ b/lib/env_guard.rb
@@ -19,9 +19,12 @@ module EnvGuard
         raise ArgumentError, "Must set the ENV variables ENVGUARD_USERNAME and ENVGUARD_PASSWORD"
       end
 
+      available_secure_compare = ActiveSupport::SecurityUtils.respond_to?(:variable_size_secure_compare) ?
+        :variable_size_secure_compare : :secure_compare
+
       authenticate_or_request_with_http_basic("Application") do |name, password|
-        granted = ActiveSupport::SecurityUtils.variable_size_secure_compare(name, (ENV['ENVGUARD_USERNAME'].presence)) &
-          ActiveSupport::SecurityUtils.variable_size_secure_compare(password, (ENV['ENVGUARD_PASSWORD'].presence))
+        granted = ActiveSupport::SecurityUtils.send(available_secure_compare, name, (ENV['ENVGUARD_USERNAME'].presence)) &
+          ActiveSupport::SecurityUtils.send(available_secure_compare, password, (ENV['ENVGUARD_PASSWORD'].presence))
         session[:authenticated_for_environment_guard] = granted
         granted
       end


### PR DESCRIPTION
Bundler decided to start error'ing out during heroku pushes because the homepage wasn't set. I set it to your website but feel free to change it to something else if you want.

![codeship_ _loopandtie_master_ _loopandtie_ _codeship](https://user-images.githubusercontent.com/780509/36572844-efa08622-180b-11e8-86c4-68f001fafdab.png)
