### PR TITLE
Rails 5.2 compatibility

### DIFF
--- a/env_guard.gemspec
+++ b/env_guard.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["dimroc@gmail.com"]
 
   spec.summary       = %q{Easily flag an environment for basic auth. Useful to protect staging.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "http://experiments.dimroc.com/"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.

--- a/lib/env_guard.rb
+++ b/lib/env_guard.rb
@@ -19,9 +19,12 @@ module EnvGuard
         raise ArgumentError, "Must set the ENV variables ENVGUARD_USERNAME and ENVGUARD_PASSWORD"
       end
 
+      available_secure_compare = ActiveSupport::SecurityUtils.respond_to?(:variable_size_secure_compare) ?
+        :variable_size_secure_compare : :secure_compare
+
       authenticate_or_request_with_http_basic("Application") do |name, password|
-        granted = ActiveSupport::SecurityUtils.variable_size_secure_compare(name, (ENV['ENVGUARD_USERNAME'].presence)) &
-          ActiveSupport::SecurityUtils.variable_size_secure_compare(password, (ENV['ENVGUARD_PASSWORD'].presence))
+        granted = ActiveSupport::SecurityUtils.send(available_secure_compare, name, (ENV['ENVGUARD_USERNAME'].presence)) &
+          ActiveSupport::SecurityUtils.send(available_secure_compare, password, (ENV['ENVGUARD_PASSWORD'].presence))
         session[:authenticated_for_environment_guard] = granted
         granted
       end


### PR DESCRIPTION
`ActiveSupport::SecurityUtils` removed `variable_size_secure_compare` in 5.2 and now `secure_compare` is suitable for variable size compares. However in 5.1 `secure_compare` is vulnerable to timing attacks so we need to favor the old method when it's available